### PR TITLE
Removed objectpath dependency that occured just once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,5 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'objectpath',
     ]
 )

--- a/wt/pygardena/device.py
+++ b/wt/pygardena/device.py
@@ -1,5 +1,4 @@
 from .account import *
-import objectpath
 
 class GardenaSmartDevice:
     def __init__(self, location, raw_data):
@@ -12,9 +11,13 @@ class GardenaSmartDevice:
         self.update()
 
     def get_value_of_property(self, ability, property):
-        abilities = objectpath.Tree(self.raw_data)
-        ability = objectpath.Tree(list(abilities.execute('$.abilities[@.type is '+ability+']'))[0])
-        return list(ability.execute('$.properties[@.name is '+property+']'))[0]['value']
+        for data_ability in self.raw_data['abilities']:
+            if data_ability['type'] != ability:
+                continue
+            for data_property in data_ability.properties:
+                if data_property['name'] == property:
+                    return data_property['value']
+        return None
 
     def update(self):
         self.raw_data = self.location.get_raw_device_data(self.id)


### PR DESCRIPTION
`objectpath` is a nice API, but its use in the project was _very_ limited. This commit removes objectpath as a dependency and replaces it by a simple iteration. It also makes the API more robust, as there are no more exceptions if an ability or property hasn't been found.