### PR TITLE
Check HTTP status response when logging in

### DIFF
--- a/wt/pygardena/rest_api.py
+++ b/wt/pygardena/rest_api.py
@@ -26,6 +26,7 @@ class RestAPI(requests.Session):
                 'password': password,
             }
         })
+        response.raise_for_status()
         return response.json()
     
     def get_locations(self, user_id):


### PR DESCRIPTION
I found that it is useful to check the HTTP status response when trying to login, as there is otherwise no indication about what went wrong when an incorrect username/password is supplied.

Drop the newline at the end if you wish, it got added by vi.